### PR TITLE
fix: Ensure party leader's game client receives battle events

### DIFF
--- a/public/games/rpg/game.js
+++ b/public/games/rpg/game.js
@@ -70,6 +70,7 @@ function init() {
     if (partyId) {
         isPartyLeader = true;
         socket = io();
+        socket.emit('rpg:register-game-socket', { username: myUsername });
         setupSocketListeners();
         const myChar = JSON.parse(localStorage.getItem('selectedCharacter'));
         if (myChar) {

--- a/server.js
+++ b/server.js
@@ -606,6 +606,14 @@ io.on('connection', (socket) => {
         }, 30000);
     });
 
+    socket.on('rpg:register-game-socket', ({ username }) => {
+        if (username && connectedUsers.has(username)) {
+            socket.username = username;
+            connectedUsers.get(username).add(socket.id);
+            console.log(`Registered new game socket ${socket.id} for user ${username}`);
+        }
+    });
+
     socket.on('rpg:respond-to-invitation', ({ from, response }) => {
         if (!socket.username) return;
 


### PR DESCRIPTION
This commit fixes a bug where the party leader would not be navigated to the battle screen after accepting a quest.

The root cause was an architectural flaw where the RPG game window, upon opening, created a new socket connection that the server was unaware of. The server was sending the `battle:started` event to the user's original socket (in the main chat window), not the new socket in the game window where the event listener was.

The fix involves:
1.  **Server-Side Socket Registration:** A new `rpg:register-game-socket` event was added to `server.js`. This allows a new game client to "introduce" itself to the server and associate its new socket with the logged-in user.
2.  **Client-Side Socket Registration:** The `game.js` client now emits this registration event immediately after establishing its socket connection, ensuring the server knows where to send game-specific events for that client.